### PR TITLE
Localization support via rainlab.translate

### DIFF
--- a/components/slider/default.htm
+++ b/components/slider/default.htm
@@ -1,5 +1,4 @@
-	
-{% if slider.slides.slideShows != 'no_slider' %}
+{% if not(slider.slides.slideShows is same as ('no_slider')) %}
 {% put scripts %}
     <script>
 		$(document).ready(function(){

--- a/models/SlideShows.php
+++ b/models/SlideShows.php
@@ -35,6 +35,14 @@ class SlideShows extends Model
     public $table = 'peterhegman_slickslider_slide_shows';
 
     protected $jsonable = ['slide_show_content', 'responsive'];
+    /**
+      * Softly implement the TranslatableModel behavior.
+      */
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+    /*
+     * @var array Attributes that support translation, if available.
+     */
+    public $translatable = ['slide_show_content'];
 
     public function afterValidate()
     {


### PR DESCRIPTION
- adding support for localization via [https://github.com/rainlab/translate-plugin](url)

- Changed string to nested array comparison as it will cause errors in twig